### PR TITLE
Disable http basic auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
   before_action :set_raven_context
-  before_action :authenticate_for_staging
+  #before_action :authenticate_for_staging
 
   private
   def authenticate_for_staging


### PR DESCRIPTION
The function `authenticate_for_staging` is now deprecated and can be
removed in a future update.

JIRA: APPS-568 / Disable HTTP Basic Auth
Epic: APPS-466 / Oral Hist. Deploy