### PR TITLE
possible fix for transient sitemap error with show pages

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -5,7 +5,7 @@
   <% if current_search_session %>
     <div id="appliedParams" class="clearfix constraints-container pull-right">
       <%= render 'start_over' %>
-      <%= link_back_to_catalog class: 'btn' %>
+      <%= link_back_to_catalog class: 'btn' if @search_context %>
     </div>
   <% end %>
 


### PR DESCRIPTION
Added a check of search_context where the back to search results button is rendered.

 ActionView::Template::Error (No route matches {:action=>"index", :controller=>"blacklight_dynamic_sitemap/sitemap", :format=>"xml", :id=>"21198-zz0008zzcd"}):
F, [2020-12-07T22:29:51.283902 #4343] FATAL -- : [e998a442-c158-4a46-b514-f4186c0517f5]      5:   <% if current_search_session %>
[e998a442-c158-4a46-b514-f4186c0517f5]      6:     <div id="appliedParams" class="clearfix constraints-container pull-right">
[e998a442-c158-4a46-b514-f4186c0517f5]      7:       <%= render 'start_over' %>
[e998a442-c158-4a46-b514-f4186c0517f5]      8:       <%= link_back_to_catalog class: 'btn' %>
[e998a442-c158-4a46-b514-f4186c0517f5]      9:     </div>
[e998a442-c158-4a46-b514-f4186c0517f5]     10:   <% end %>
[e998a442-c158-4a46-b514-f4186c0517f5]     11: