### PR TITLE
OH-117 Remove links from oral history navbar

### DIFF
--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -40,7 +40,6 @@
           <li class="dropdown-item"><%= link_to 'Family History Sample Outline', asset_path("Family_History_Sample_Outline.pdf", class: 'dropdown-link') %></li>
           <li class="dropdown-item"><%= link_to 'Selected Oral History Organizations', organizations_path, class: 'dropdown-link' %></li>
           <li class="dropdown-item"><%= link_to 'Oral History Training', training_path, class: 'dropdown-link' %></li>
-          <li class="dropdown-item"><%= link_to 'Bibliography', bibliography_path, class: 'dropdown-link' %></li>
         </ul>
       </li>
 


### PR DESCRIPTION
Connected to [OH-117](https://jira.library.ucla.edu/browse/OH-117)

Removes the following two links from the Center for Oral History Research website Resources drop down (top menu bar):
- [x] "Selected Oral History Programs"- https://oralhistory.library.ucla.edu/pages/programs
- [x] "Bibliography" - https://oralhistory.library.ucla.edu/pages/bibliography

<img width="1185" alt="Screen Shot 2021-01-25 at 12 15 13 PM" src="https://user-images.githubusercontent.com/751697/105760758-15cb8000-5f07-11eb-89b6-ee7f1c999f1b.png">
