### PR TITLE
OH-121 Update 2 links on oral history pages

### DIFF
--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -38,8 +38,8 @@
           <li class="dropdown-item"><%= link_to 'Interviewing Guidelines', asset_path("Interviewing_Guidelines.pdf", class: 'dropdown-link') %></li>
           <li class="dropdown-item"><%= link_to 'Sample Legal Agreement', asset_path("SampleLegalAgreement.pdf", class: 'dropdown-link') %></li>
           <li class="dropdown-item"><%= link_to 'Family History Sample Outline', asset_path("Family_History_Sample_Outline.pdf", class: 'dropdown-link') %></li>
-          <li class="dropdown-item"><%= link_to 'Selected Oral History Organizations', organizations_path, class: 'dropdown-link' %></li>
-          <li class="dropdown-item"><%= link_to 'Oral History Training', training_path, class: 'dropdown-link' %></li>
+          <li class="dropdown-item"><%= link_to 'Selected Oral History Organizations', 'https://www.ioha.org/', class: 'dropdown-link' %></li>
+          <li class="dropdown-item"><%= link_to 'Oral History Training', 'https://www.baylor.edu/library/index.php?id=974108', class: 'dropdown-link' %></li>
         </ul>
       </li>
 


### PR DESCRIPTION
Connected to [OH-121](https://jira.library.ucla.edu/browse/OH-121)

- [x] In the nav bar under Resources > Selected Oral History Organizations, the first organization listed - International Oral History Association - should link to https://www.ioha.org/. 
- [x] In the nav bar under Resources > Oral History Training, the link to Baylor University's Institute for Oral History (last sentence on the page) should link to https://www.baylor.edu/library/index.php?id=974108 

---

Changes to be committed:
modified:   `app/views/shared/_user_util_links.html.erb`