### PR TITLE
change document ready function to turbolinks load function

### DIFF
--- a/app/assets/javascripts/timestamp_links.js
+++ b/app/assets/javascripts/timestamp_links.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(document).on('turbolinks:load', function() {
   $('body').on('click', '.audio-timestamp-link', function(e) {
     var event = new CustomEvent(
       'jump_to_audio_time',


### PR DESCRIPTION
Audio timestamp links were not functioning unless the page reloads. Fixed by changing the document.ready function to document.on turbolinks:load function

Connected to [141](https://gitlab.com/notch8/oral_history/-/issues/141)