### PR TITLE
remove description field from index page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -23,7 +23,7 @@ class CatalogController < ApplicationController
       :"hl.fl" => "abstract_t, biographical_t, subject_t, description_t, audio_b, extent_t, language_t, author_t, interviewee_t, title_t, subtitle_t, series_t",
       :"hl.simple.pre" => "<span class='label label-warning'>",
       :"hl.simple.post" => "</span>",
-      :"hl.fragsize" => 200,
+      :"hl.fragsize" => 100,
     }
 
     # solr path which will be added to solr base url before the other solr params.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,7 +66,7 @@ module ApplicationHelper
   end
 
   def index_filter options={}
-    "#{ options[:value][0].truncate(100)}".html_safe
+    "#{ options[:value][0].truncate(150)}".html_safe
   end
 
   def highlightable_series_link(options={})


### PR DESCRIPTION
- Removes the description field from the search results (index) page
- Removes unnecessary tags from helper method
- Adjust highlight snippet size and truncate size so highlight snippets aren't missing the highlight tags (which causes formatting errors for longer text fields)
<img width="1156" alt="Screen Shot 2021-06-30 at 5 21 05 PM" src="https://user-images.githubusercontent.com/18175797/125983758-f86f3087-9014-4f60-8776-f23b836e78a1.png">
