### PR TITLE
Update ca-certificates early

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM phusion/passenger-ruby25:1.0.11
 
 RUN echo 'Downloading Packages' && \
+    apt-get update -qq -o Dir::Etc::sourceparts=- && \
+    apt-get install -y  \
+      ca-certificates \
+      && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     curl -sL https://deb.nodesource.com/setup_12.x | bash - && \


### PR DESCRIPTION
Resolve Let's Encrypt root certificate update

E: The repository 'https://oss-binaries.phusionpassenger.com/apt/passenger bionic Release' does not have a Release file.
Error executing command, exiting

Should solve:
buildx call failed with: error: failed to solve: process "/bin/sh -c echo 'Downloading Packages' &&     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - &&     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | tee /etc/apt/sources.list.d/yarn.list &&     curl -sL https://deb.nodesource.com/setup_12.x | bash - &&     apt-get update -qq &&     apt-get install -y        build-essential       default-jdk       ffmpeg       imagemagick       libpq-dev       libsasl2-dev       libsndfile1-dev       nodejs       postgresql-client       pv       tzdata       unzip       yarn       zip       &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&     yarn config set no-progress &&     yarn config set silent &&     echo 'Packages Downloaded'" did not complete successfully: exit code: 1

Likely due to Let's Encrypt root certificate updates