### PR TITLE
increase size of truncation on index_filter helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,7 +66,7 @@ module ApplicationHelper
   end
 
   def index_filter options={}
-    "#{ options[:value][0].truncate(150)}".html_safe
+    "#{ options[:value][0].truncate(300)}".html_safe
   end
 
   def highlightable_series_link(options={})


### PR DESCRIPTION
Fixes the text formatting issue where the highlight end tags are being truncated

Issue https://gitlab.com/notch8/oral_history/-/issues/160

Screenshot of fixed search results:

![UCLA-OH-truncate](https://user-images.githubusercontent.com/18175797/145886429-b118d142-c696-497e-b2f6-bab57df27122.png)

