### PR TITLE
in the Accessing Interviews section, changed text to UCLA UC Search, …

### DIFF
--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -55,7 +55,7 @@
       </div>
       <div class="tab-pane fade g-brd-top g-brd-gray-light-v4 g-color-gray-dark-v5" id="training"  aria-labelledby="training-tab">
         <p>
-          Interested in doing an oral history project? The Center for Oral History Research offers a biannual workshop that provides an introduction to the basics of oral history methodology.  Find further information <a href="/pages/training">here</a>
+          Interested in doing an oral history project? The Center for Oral History Research offers a biannual workshop that provides an introduction to the basics of oral history methodology.  Find further information <a href="/pages/training">here</a>.
         </p>
       </div>
       <div class="tab-pane fade g-brd-top g-brd-gray-light-v4 g-color-gray-dark-v5" id="interviews"  aria-labelledby="interviews-tab">
@@ -63,7 +63,7 @@
           The transcripts and recordings for many of COHR’s interviews are available on this website under the individual interview entries.
         </p>
         <p>
-          Transcripts and recordings not available here can be accessed in person at UCLA Library Special Collections. To have materials paged to the Special Collections reading room, users can register with the <a href="https://speccoll.library.ucla.edu/">UCLA Library Special Collections Request System</a> and then click on "Request an Item." The "Call Number/Collection Number" that the form asks for can be found in the entry for the interview in the <a href="https://catalog.library.ucla.edu/vwebv/searchBasic">UCLA Library Catalog</a>.
+          Transcripts and recordings not available here can be accessed in person at UCLA Library Special Collections. To have materials paged to the Special Collections reading room, users can register with the <a href="https://speccoll.library.ucla.edu/">UCLA Library Special Collections Request System</a> and then click on "Request an Item." The "Call Number/Collection Number" that the form asks for can be found in the entry for the interview in <a href="https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA">UC Library Search</a>.
         </p>
         <p>
           If donation agreements allow, interview transcripts not available through this website can be provided to users as PDFs. To request a PDF, please register with the <a href="https://speccoll.library.ucla.edu/">UCLA Library Special Collections Request System</a> and request "Photoduplication."


### PR DESCRIPTION
…updated link from old UCLA Library catalog to UC Search; in Oral History Training section, added period after Find further information here.
Connected to [OH-134](https://jira.library.ucla.edu/browse/OH-134)

[OH-134]: https://uclalibrary.atlassian.net/browse/OH-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ