### PR TITLE
17-index-pdf-transcripts-metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,4 @@ In Jenkins, select `docker_swarm_deploy` job. Use `Build with Parameters`. Selec
 
 Regarding `docker-compose.production.yml`: The delayed_job container is for scaling out processing of peaks for all of the audio files.
 However, the web container always has one worker.
-Stopping the delayed_job container will not stop jobs from being run.
+Stopping the delayed_job container will not stop jobs from being  run. 

--- a/app/jobs/index_pdf_transcript_job.rb
+++ b/app/jobs/index_pdf_transcript_job.rb
@@ -7,15 +7,23 @@ class IndexPdfTranscriptJob < ApplicationJob
     item = OralHistoryItem.find_or_new(id)
     # make call to solr for extraction
     tmp_file = Tempfile.new
-    
+
     tmp_file.binmode
     `curl -o #{tmp_file.path} #{pdf_text}`
-                  
+
     if tmp_file.size > 0
       result = SolrService.extract(path: tmp_file.path)
-      # put response in this field 
+      transcript = result['file'].to_s.strip
+
+      # put transcript into these fields
       item.attributes['transcripts_t'] ||= []
-      item.attributes['transcripts_t'] << result[File.basename(tmp_file.path)].to_s.strip
+      item.attributes['transcripts_t'] << transcript
+      item.attributes['transcripts_json_t'] ||= []
+      item.attributes['transcripts_json_t'] << {
+        'transcript_t': transcript
+      }.to_json
+
+      # index the record in Solr
       item.index_record
     end
   end

--- a/app/models/oral_history_item.rb
+++ b/app/models/oral_history_item.rb
@@ -201,7 +201,7 @@ class OralHistoryItem
 
             if child.elements['mods:location/mods:url[@usage="timed log"]'].present?
               time_log_url = child.elements['mods:location/mods:url[@usage="timed log"]'].text
-              transcript = self.generate_transcript(time_log_url)
+              transcript = self.generate_xml_transcript(time_log_url)
               history.attributes["transcripts_json_t"] << {
                 "transcript_t": transcript,
                 "order_i": order
@@ -272,6 +272,7 @@ class OralHistoryItem
           elsif child.name == 'location'
             child.elements.each do |f|
               history.attributes['links_t'] << [f.text, f.attributes['displayLabel']].to_json
+              order = child.elements['mods:part'].present? ? child.elements['mods:part'].attributes['order'] : 1
               if f.attributes['displayLabel'] &&
                 has_xml_transcripts == false &&
                 history.attributes["transcripts_t"].blank? &&
@@ -279,6 +280,9 @@ class OralHistoryItem
                 f.text.match(/pdf/i)
                 history.should_process_pdf_transcripts = true
                 pdf_text = f.text
+                history.attributes["transcripts_json_t"] << {
+                  "order_i": order
+                }.to_json
               end
             end
           elsif child.name == 'physicalDescription'
@@ -367,7 +371,7 @@ class OralHistoryItem
     OralHistoryItem.new(id: id)
   end
 
-  def self.generate_transcript(url)
+  def self.generate_xml_transcript(url)
     tmpl = Nokogiri::XSLT(File.read('public/convert.xslt'))
     resp = Net::HTTP.get(URI(url))
 
@@ -396,8 +400,17 @@ class OralHistoryItem
     Delayed::Job.where("handler LIKE ? AND last_error IS ?", "%job_class: ProcessPeakJob%#{self.id}%", nil).present?
   end
 
+  def pdf_transcript_job_queued?
+    Delayed::Job.where("handler LIKE ? AND last_error IS ?", "%job_class: IndexPdfTranscriptJob%#{self.id}%", nil).present?
+  end
+
   def should_process_peaks?
     !has_peaks? && !peak_job_queued?
+  end
+
+  def should_process_pdf_transcripts
+    @should_process_pdf_transcripts ||= false
+    @should_process_pdf_transcripts && !pdf_transcript_job_queued?
   end
 
   def self.create_import_tmp_file


### PR DESCRIPTION
ref ticket: https://github.com/scientist-softserv/oral-history/issues/17

Rename generate transcripts to xml specific, update to add order and update the job to include needed metadata for the search and transcripts display to work.

Prod: https://oralhistory.library.ucla.edu/catalog/21198-zz002kpkk3
Staging: https://oralhistory-test.library.ucla.edu/catalog/21198-zz002kpkk3
Local: http://hyku.test/catalog/21198-zz002kpkk3

Drop into web container terminal in docker desktop and run:
`bundle exec rails c`
`OralHistoryItem.import_single('21198-zz002kpkk3')`

Feed: https://webservices.library.ucla.edu/dldataprovider/oai2_0.do?metadataPrefix=mods&verb=GetRecord&identifier=oai:library.ucla.edu:digital2/21198-zz002kpkk3

<details><summary>CLICK ME Screenshots</summary>
<img width="1728" alt="Screenshot 2023-03-26 at 17 14 19" src="https://user-images.githubusercontent.com/63515648/227813893-e00440fc-16f3-4001-8a75-46ac4f9c667d.png">

<img width="1728" alt="Screenshot 2023-03-26 at 16 53 12" src="https://user-images.githubusercontent.com/63515648/227813088-329c0d00-916b-45d0-aff8-9f96d889220b.png">
<img width="1161" alt="Screenshot 2023-03-26 at 16 52 54" src="https://user-images.githubusercontent.com/63515648/227813092-cad1ec3a-47ce-493b-97ff-56a95e3fbb79.png">
</details>
