### PR TITLE
I53 make base oai url env var everywhere

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,7 @@ DOCKER_PORTS=80
 MAKE_WAVES=true # Set to false to disable Waveform generation
 NEGATIVE_CAPTCHA_SECRET=64fe54311a8e54b637a1da1ff993b560ff5c742211f645f35b8b9bd8b3d2e4015e95dea8db4dc235df0396ddd94d21d18d0c787bcaa5b579cb5f6f2aac90e601
 SECRET_KEY_BASE=CHANGEME
+OH_STAFF_DOMAIN="oh-staff.library.ucla.edu"
 PASSENGER_APP_ENV=development
 POSTGRES_DB=oral_history
 POSTGRES_HOST=postgres

--- a/app/models/oral_history_item.rb
+++ b/app/models/oral_history_item.rb
@@ -26,7 +26,8 @@ class OralHistoryItem
 
 
   def self.client(args)
-    url = args[:url] || "https://oh-staff.library.ucla.edu/oai/"
+    domain = ENV['OAI_BASE_URL'] || 'oh-staff.library.ucla.edu'
+    url = args[:url] || "http://#{domain}/oai"
 
     OAI::Client.new(url, http: Faraday.new {|c| c.options.timeout = 300})
   end
@@ -417,7 +418,8 @@ class OralHistoryItem
   end
 
   def self.total_records(args = {})
-    url = args[:url] || "https://oh-staff.library.ucla.edu/oai/"
+    domain = ENV['OAI_BASE_URL'] || 'oh-staff.library.ucla.edu'
+    url = args[:url] || "http://#{domain}/oai"
 
     OAI::Client.new(url, http: Faraday.new {|c| c.options.timeout = 300})
   end

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.0.2"
 description: Chart for Oral History Public-Facing App
 name: oralhistory
-version: 1.0.4
+version: 1.0.5
 
 # The `appVersion` is not a required field whereas `version` is required. If
 # you’re making changes to a helm chart template file and/or the default values

--- a/charts/prod-oralhistory-values.yaml
+++ b/charts/prod-oralhistory-values.yaml
@@ -73,6 +73,10 @@ postgresql:
 web:
   # Due to the current Helm template mechanism, any additional ENVs will have to be added in the oral-history-env ConfigMap template
   env:
+    # The Oral History Applications base domain url for the
+    # dynamic setting of the oai url for multiple environments
+    OAI_BASE_URL: "oralhistory.library.ucla.edu"
+
     # Solr Environment Variables
     # The values should be matched with values used in the Solr Dependent Chart
     SOLR_ADMIN_USER: "admin"

--- a/charts/stage-oralhistory-values.yaml
+++ b/charts/stage-oralhistory-values.yaml
@@ -73,6 +73,10 @@ postgresql:
 web:
   # Due to the current Helm template mechanism, any additional ENVs will have to be added in the oral-history-env ConfigMap template
   env:
+    # The Oral History Applications base domain url for the
+    # dynamic setting of the oai url for multiple environments
+    OAI_BASE_URL: "oralhistory.library.ucla.edu"
+
     # Solr Environment Variables
     # The values should be matched with values used in the Solr Dependent Chart
     SOLR_ADMIN_USER: "admin"

--- a/charts/templates/deployment-worker.yaml
+++ b/charts/templates/deployment-worker.yaml
@@ -46,6 +46,11 @@ spec:
             - secretRef:
                 name: {{ include "chart.fullname" . }}-secrets
           env:
+            - name: OAI_BASE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: oral-history-env
+                  key: OAI_BASE_URL
             - name: SOLR_ADMIN_USER
               valueFrom:
                 configMapKeyRef:

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -45,6 +45,11 @@ spec:
             - secretRef:
                 name: {{ include "chart.fullname" . }}-secrets
           env:
+            - name: OAI_BASE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: oral-history-env
+                  key: OAI_BASE_URL
             - name: SOLR_ADMIN_USER
               valueFrom:
                 configMapKeyRef:

--- a/charts/test-oralhistory-values.yaml
+++ b/charts/test-oralhistory-values.yaml
@@ -73,6 +73,10 @@ postgresql:
 web:
   # Due to the current Helm template mechanism, any additional ENVs will have to be added in the oral-history-env ConfigMap template
   env:
+    # The Oral History Applications base domain url for the
+    # dynamic setting of the oai url for multiple environments
+    OAI_BASE_URL: "oralhistory.library.ucla.edu"
+
     # Solr Environment Variables
     # The values should be matched with values used in the Solr Dependent Chart
     SOLR_ADMIN_USER: "admin"


### PR DESCRIPTION
Have the base oai feed url in an env variable everywhere.

Add the new variable to:
- oral_history_item model
- .env
- deployment template
- deployment-worker templates
- test-oralhistory-values file
- stage-oralhistory-values file
- prod-oralhistory-values file

Trigger new chart
