### PR TITLE
update-ghas-exclude-charts-dir-on-build-push

### DIFF
--- a/.github/workflows/build-dockerhub.yml
+++ b/.github/workflows/build-dockerhub.yml
@@ -3,9 +3,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'charts/**'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'charts/**'
 
 jobs:
   build-for-docker-hub:


### PR DESCRIPTION
Ignore the charts path when building and pushing docker images in ghas