### PR TITLE
Added the MAKE_WAVES env var to worker deployment yaml

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.0.2"
 description: Chart for Oral History Public-Facing App
 name: oralhistory
-version: 1.0.5
+version: 1.0.6
 
 # The `appVersion` is not a required field whereas `version` is required. If
 # you’re making changes to a helm chart template file and/or the default values

--- a/charts/templates/deployment-worker.yaml
+++ b/charts/templates/deployment-worker.yaml
@@ -64,6 +64,11 @@ spec:
                   key: SOLR_ADMIN_PASSWORD
             - name: SOLR_URL
               value: http://$(SOLR_ADMIN_USER):$(SOLR_ADMIN_PASSWORD)@$(SOLR_HOST):$(SOLR_PORT)/solr/blacklight-core
+            - name: MAKE_WAVES
+              valueFrom:
+                configMapKeyRef:
+                  name: oral-history-env
+                  key: MAKE_WAVES
           ports:
             - name: http
               containerPort: 80


### PR DESCRIPTION
Another fix for missed env setting -- any CRUD operations on environment variables should review the following files:
- [environment]-oralhistory-values.yaml
- deployment[-worker].yaml