### PR TITLE
Removed ProcessPeakJob execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # Docker Development Setup
 
 - Install Docker ([macOS](https://docs.docker.com/docker-for-mac/install/)/[Windows](https://docs.docker.com/docker-for-windows/install/)/[Linux](https://docs.docker.com/engine/install/))
-- `.env` is populated with good defaults.
 - Copy `.env` to `.env.development`
-- Build project and start up
+- Run `docker compose up --build`
 
 ```bash
 docker compose build
 docker compose up
 ```
 
-- Visit 127.0.0.1:8000 in your browser.
+- Visit [127.0.0.1:8000](127.0.0.1:8000) in your browser.
 - The first time the application is brought up, some database updates need to be made due to shifting dependencies
 
 - Identify your postgres container and run the following:
@@ -40,8 +39,14 @@ docker compose exec web bundle exec rake import[100]
 ```
 
 - Sign into the Admin Dashboard
-  Navigate to https://127.0.0.1:8000/users/sign_in
+  Navigate to [https://127.0.0.1:8000/users/sign_in](https://127.0.0.1:8000/users/sign_in)
   Login with default the seeded user and password at db/seeds.rb
+
+  The default development username and password are:
+
+  - admin@example.com
+  - password
+
   Note you can add those ENV variable to your .env file to update
   the values in one place. But deafults are set so make sure you
   update for produciton environment.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Optional: Contact DevSupport for Argo account for log access
 
 - Submit a pull and review request. On [**submission** of a pull request](https://github.com/UCLALibrary/oral-history/blob/main/.github/workflows/build-dockerhub.yml), a container image is built and pushed to Docker Hub. Update the pull request and incorporate any change requests required from the review. Any new commits or changes to the pull request will trigger a new container image to be created and pushed to Docker Hub.
 
-- Navigate to Docker Hub and note the image tag, which is the first 8 characters of the hash.
+- Navigate to [Docker Hub](https://hub.docker.com/repository/docker/uclalibrary/oral-history) (login required) and note the image tag, which is the first 8 characters of the hash.
 
 - In the appropriate `charts/[environment]-oralhistory-values.yaml` file, update the `image: tag` value to the tag copied from Docker Hub in the previous step. This should be the final commit before merging the pull request.
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,18 @@
 # Docker Development Setup
 
 - Install Docker ([macOS](https://docs.docker.com/docker-for-mac/install/)/[Windows](https://docs.docker.com/docker-for-windows/install/)/[Linux](https://docs.docker.com/engine/install/))
+
 - Copy `.env` to `.env.development`
 - Run `docker compose up --build`
 
-```bash
-docker compose build
-docker compose up
-```
+If you are running Linux, some additional steps are required:
 
-- Visit [127.0.0.1:8000](127.0.0.1:8000) in your browser.
-- The first time the application is brought up, some database updates need to be made due to shifting dependencies
+- A local user/group on your (host) machine must match the `app` user.
+- Create a new user/group with uid/gid 9999.
+- Set the proper permissions inside the `web` container.
+- Make sure you are in `/home/app/webapp` and run `chown -R app:app .`
 
-- Identify your postgres container and run the following:
-
-```
-docker ps
-# Note container id below
-a320a4fabaac   postgres:15                    "docker-entrypoint.s…"
-# Shell into container
-docker exec -it [container id from above] /bin/bash
-
-/bin/psql --username=postgres
-
-ALTER DATABASE oral_history REFRESH COLLATION VERSION;
-ALTER DATABASE oral_history_test REFRESH COLLATION VERSION;
-ALTER DATABASE postgres REFRESH COLLATION VERSION;
-ALTER DATABASE template0 REFRESH COLLATION VERSION;
-ALTER DATABASE template1 REFRESH COLLATION VERSION;
-```
-
-- Load database and import data
+Load database and import some sample data using the following commands
 
 ```
 docker compose exec web bundle exec rake db:migrate
@@ -38,36 +20,40 @@ docker compose exec web bundle exec rake db:seed
 docker compose exec web bundle exec rake import[100]
 ```
 
-- Sign into the Admin Dashboard
-  Navigate to [https://127.0.0.1:8000/users/sign_in](https://127.0.0.1:8000/users/sign_in)
-  Login with default the seeded user and password at db/seeds.rb
+If you get an error on the final line, and are using the `zsh` shell, you will need to escape the square brackets.
 
-  The default development username and password are:
-
-  - admin@example.com
-  - password
-
-  Note you can add those ENV variable to your .env file to update
-  the values in one place. But deafults are set so make sure you
-  update for produciton environment.
-
-- Common Developer Recipes:
-  Drop into a bash console inside docker container:
-  `docker compose exec container-name bash`
-  Example: `docker compose exec web bash`
-
-  Drop into a sh console inside docker container:
-  `docker compose exec container-name sh`
-  Example: `docker compose exec web sh`
-  Drop into a rails console:
-  `docker compose exec bundle exec rails c`
+```
+docker compose exec web bundle exec rake import\[100\]
+```
 
 **Note:** The `100` in `import[100]` limits the number of assets initially loaded. You may adjust this as desired.
 
-## Development Notes
+At this point you should be able to access the application at [http://127.0.0.1:8000/](http://127.0.0.1:8000/)
 
-When performing an import the system will attempt to download and process the audio files to create the peak files. This is very CPU & time intense.
-**To avoid this** change `MAKE_WAVES` in your `.env` to false (or delete it).
+Sign into the Admin Dashboard
+
+- Navigate to [http://127.0.0.1:8000/users/sign_in](http://127.0.0.1:8000/users/sign_in)
+
+The default development username and password are:
+
+- `admin@example.com`
+- `password`
+
+Common Developer Recipes:
+
+Drop into a bash console inside docker container:
+
+- `docker compose exec container-name bash`
+- Example: `docker compose exec web bash`
+
+Drop into a sh console inside docker container:
+
+- `docker compose exec container-name sh`
+- Example: `docker compose exec web sh`
+
+Drop into a rails console:
+
+- `docker compose exec bundle exec rails c`
 
 # Build and Deploy Process
 

--- a/app/models/oral_history_item.rb
+++ b/app/models/oral_history_item.rb
@@ -74,9 +74,7 @@ class OralHistoryItem
           else
             OralHistoryItem.index_logger.info("ID is nil for #{history.inspect}")
           end
-          if ENV['MAKE_WAVES'] && history.attributes["audio_b"] && history.should_process_peaks?
-            ProcessPeakJob.perform_later(history.id)
-          end
+          # The ProcessPeakJob logic was previously here and has been removed until full fix is implemented
         rescue => exception
           Rollbar.error('Error processing record', exception)
           OralHistoryItem.index_logger.error("#{exception.message}\n#{exception.backtrace}")
@@ -108,9 +106,8 @@ class OralHistoryItem
     record = self.get(identifier: converted_id)&.record
     history = process_record(record)
     history.index_record
-    if ENV['MAKE_WAVES'] && history.attributes["audio_b"] && history.should_process_peaks?
-      ProcessPeakJob.perform_later(history.id)
-    end
+
+    # The ProcessPeakJob logic was previously here and has been removed until full fix is implemented
     return history
   rescue => exception
     Rollbar.error('Error importing record', exception)

--- a/charts/stage-oralhistory-values.yaml
+++ b/charts/stage-oralhistory-values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: uclalibrary/oral-history
   # changing this tag will cause a deploy via ArgoCD
-  tag: 0b40962d
+  tag: 9becf1d1
   pullPolicy: Always
 
 # Chart documentation: https://github.com/bitnami/charts/tree/main/bitnami/solr


### PR DESCRIPTION
This is part 1 of resolving the `ProcessPeakJob` wav form generation. This PR completely removes the call of `ProcessPeakJob` calls, but does not remove the function definition.

If wav form image data already exists, it will not be removed when re-importing a record. If the record is new, a wav form image will not be created. Existing wav form image data is in JSON format and stored in Solr.

To confirm:

- Clone repo
- Rebuild using `docker compose up --build`
- Navigate to [http://127.0.0.1:8000/admin](http://127.0.0.1:8000/admin)
- Use `admin@example.com` and `password` as credentials
- Click `Destroy All Delayed Jobs`. This ensures the job queue is empty

Compare an existing entry that has a wav form image to our local instance
- Open production entry at [https://oralhistory.library.ucla.edu/catalog/21198-zz002khbcc](https://oralhistory.library.ucla.edu/catalog/21198-zz002khbcc) in browser 
- Import local matching entry in the admin interface, enter `21198-zz002khbcc` then click `Run Single Import`
- Open matching local entry at [http://127.0.0.1:8000/catalog/21198-zz002khbcc](http://127.0.0.1:8000/catalog/21198-zz002khbcc) in browser
- Observe no wav form image in the local instance
- Re-import this specific record in the [local admin interface](http://127.0.0.1:8000/admin)
- Enter `21198-zz002khbcc` and click `Run Single Import`, wait until entry is imported
- Reload the local entry at [http://127.0.0.1:8000/catalog/21198-zz002khbcc](http://127.0.0.1:8000/catalog/21198-zz002khbcc)
- No wav form image will appear, though the audio does exist, as verified by the [production entry](https://oralhistory.library.ucla.edu/catalog/21198-zz002khbcc)