### PR TITLE
Added exception inside generate_xml_transcript, which was throwing er…

### DIFF
--- a/app/models/oral_history_item.rb
+++ b/app/models/oral_history_item.rb
@@ -416,12 +416,16 @@ class OralHistoryItem
   end
 
   def self.generate_xml_transcript(url)
-    tmpl = Nokogiri::XSLT(File.read('public/convert.xslt'))
-    resp = Net::HTTP.get(URI(url))
+    begin
+      tmpl = Nokogiri::XSLT(File.read('public/convert.xslt'))
+      resp = Net::HTTP.get(URI(url))
 
-    document = Nokogiri::XML(resp)
+      document = Nokogiri::XML(resp)
 
-    tmpl.transform(document).to_xml
+      tmpl.transform(document).to_xml
+    rescue => exception
+      OralHistoryItem.index_logger.error("#{exception.message}\n#{exception.backtrace}")
+    end
   end
 
   def self.total_records(args = {})


### PR DESCRIPTION
Minor change to add exception logging for an error that was manifesting on production, logs pointed to the `generate_xml_transcript` call.

In the case where the oai code indicates a timed log is present but the transcript is missing, unavailable, or unable to be interpreted by the XSLT -- this could cause an error that breaks the application.