### PR TITLE
SYS-1656: Enable external solr access for test environment

### DIFF
--- a/charts/test-oralhistory-values.yaml
+++ b/charts/test-oralhistory-values.yaml
@@ -32,6 +32,17 @@ solr:
   zookeeper:
     enabled: false
 
+  ingress:
+    enabled: true
+    ingressClassName: "nginx"
+    hostname: "oralhistory-test-solr.library.ucla.edu"
+    path: "/"
+    annotations:
+      cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
+      kubernetes.io/tls-acme: "true"
+      nginx.ingress.kubernetes.io/whitelist-source-range: "164.67.48.211/32"
+    tls: true
+
   image:
     repository: bitnami/solr
     # This is the image version, not the chart version.


### PR DESCRIPTION
Implements [SYS-1656](https://uclalibrary.atlassian.net/browse/SYS-1656), for the *test* environment only.

This PR adds `ingress` information to the `solr` stanza of `test-oralhistory-values.yaml`, enabling external access to solr.  Access is allowed only via our internal jump server.

@kjallen FYI


[SYS-1656]: https://uclalibrary.atlassian.net/browse/SYS-1656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ