### PR TITLE
SYS-1656: Enable external solr access for production environment

### DIFF
--- a/charts/prod-oralhistory-values.yaml
+++ b/charts/prod-oralhistory-values.yaml
@@ -32,6 +32,18 @@ solr:
   zookeeper:
     enabled: false
 
+  # Allow access to solr from the jump server, for library data indexing project
+  ingress:
+    enabled: true
+    ingressClassName: "nginx"
+    hostname: "oralhistory-solr.library.ucla.edu"
+    path: "/"
+    annotations:
+      cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
+      kubernetes.io/tls-acme: "true"
+      nginx.ingress.kubernetes.io/whitelist-source-range: "164.67.48.211/32"
+    tls: true
+
   image:
     repository: bitnami/solr
     # This is the image version, not the chart version.


### PR DESCRIPTION
Implements [SYS-1656](https://uclalibrary.atlassian.net/browse/SYS-1656), for the production environment (test done via #126).

This PR adds `ingress` information to the `solr` stanza of `prod-oralhistory-values.yaml`, enabling external access to solr.  Access is allowed only via our internal jump server.

No deployment steps are needed, since this updates only the chart values - it does not change code or build a new Docker image.  It also does not change anything about how solr works within the system; it just allows access from the outside, via the new hostname.

Once merged, ArgoCD will sync to update the chart values and everything should work automatically.


[SYS-1656]: https://uclalibrary.atlassian.net/browse/SYS-1656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ